### PR TITLE
Fixed handling of large sequence numbers

### DIFF
--- a/tcp_assembly.go
+++ b/tcp_assembly.go
@@ -411,9 +411,9 @@ func (w *ReceiveWindow) expand() {
 // compare two tcp sequences, if seq1 is earlier, return num < 0, if seq1 == seq2, return 0, else return num > 0
 func compareTCPSeq(seq1, seq2 uint32) int {
 	if seq1 < tcpSeqWindow && seq2 > maxTCPSeq-tcpSeqWindow {
-		return int(seq1 + maxTCPSeq - seq2)
+		return int(int32(seq1 + maxTCPSeq - seq2))
 	} else if seq2 < tcpSeqWindow && seq1 > maxTCPSeq-tcpSeqWindow {
-		return int(seq1 - (maxTCPSeq + seq2))
+		return int(int32(seq1 - (maxTCPSeq + seq2)))
 	}
 	return int(int32(seq1 - seq2))
 }


### PR DESCRIPTION
There was a bug in `compareTCPSeq` on 64bit architectures.
When `seq1` or `seq2` were larger than `maxTCPSeq`, the result of `seq1 - (maxTCPSeq + seq2)`  was supposed to be cast to int32 and result in a negative value but ended up positive. 
This caused packets to be dropped in line 314.